### PR TITLE
Add 4 new vibration methods, and refactor code.

### DIFF
--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
@@ -5,6 +5,7 @@ import android.os.Vibrator;
 import android.content.Context;
 import android.provider.Settings;
 import android.view.HapticFeedbackConstants;
+import com.mkuczera.VibrateFactory;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -36,67 +37,14 @@ public class RNReactNativeHapticFeedbackModule extends ReactContextBaseJavaModul
 
     Vibrator v = (Vibrator) reactContext.getSystemService(Context.VIBRATOR_SERVICE);
     if (v == null) return;
-    long durations[] = {0, 20};
-    int hapticConstant = 0;
 
-    switch (type) {
-      case "impactLight":
-        durations = new long[]{0, 20};
-        break;
-      case "impactMedium":
-        durations = new long[]{0, 40};
-        break;
-      case "impactHeavy":
-        durations = new long[]{0, 60};
-        break;
-      case "notificationSuccess":
-        durations = new long[]{0, 40 ,60, 20};
-        break;
-      case "notificationWarning":
-        durations = new long[]{0, 20, 60, 40};
-        break;
-      case "notificationError":
-        durations = new long[]{0, 20, 40, 30, 40, 40};
-        break;
-      case "rigid":
-        durations = new long[]{0, 30};
-        break;
-      case "soft":
-        durations = new long[]{0, 10};
-        break;
-      case "clockTick":
-        hapticConstant = HapticFeedbackConstants.CLOCK_TICK;
-        break;
-      case "contextClick":
-        hapticConstant = HapticFeedbackConstants.CONTEXT_CLICK;
-        break;
-      case "keyboardPress":
-        hapticConstant = HapticFeedbackConstants.KEYBOARD_PRESS;
-        break;
-      case "keyboardRelease":
-        hapticConstant = HapticFeedbackConstants.KEYBOARD_RELEASE;
-        break;
-      case "keyboardTap":
-        hapticConstant = HapticFeedbackConstants.KEYBOARD_TAP;
-        break;
-      case "longPress":
-        hapticConstant = HapticFeedbackConstants.LONG_PRESS;
-        break;
-      case "textHandleMove":
-        hapticConstant = HapticFeedbackConstants.TEXT_HANDLE_MOVE;
-        break;
-      case "virtualKey":
-        hapticConstant = HapticFeedbackConstants.VIRTUAL_KEY;
-        break;
-      case "virtualKeyRelease":
-        hapticConstant = HapticFeedbackConstants.VIRTUAL_KEY_RELEASE;
-        break;
-      }
+    Operation targetVibration = VibrateFactory
+      .getOperation(type)
 
-      if (hapticConstant != 0) {
-        v.vibrate(hapticConstant);
-      } else {
-        v.vibrate(durations, -1);
-      }
+    if (!targetVibration.isPresent()) {
+      return;
+    }
+
+    targetVibration.apply(v);
   }
 }

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
@@ -36,13 +36,9 @@ public class RNReactNativeHapticFeedbackModule extends ReactContextBaseJavaModul
     if (ignoreAndroidSystemSettings == false && hapticEnabledAndroidSystemSettings == 0) return;
 
     Vibrator v = (Vibrator) reactContext.getSystemService(Context.VIBRATOR_SERVICE);
-    if (v == null) return;
-
     Vibrate targetVibration = VibrateFactory.getVibration(type);
 
-    if (targetVibration == null) {
-      return;
-    }
+    if (v == null || targetVibration == null) return;
 
     targetVibration.apply(v);
   }

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
@@ -5,6 +5,7 @@ import android.os.Vibrator;
 import android.content.Context;
 import android.provider.Settings;
 import com.mkuczera.VibrateFactory;
+import com.mkuczera.Vibrate;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -37,9 +38,9 @@ public class RNReactNativeHapticFeedbackModule extends ReactContextBaseJavaModul
     Vibrator v = (Vibrator) reactContext.getSystemService(Context.VIBRATOR_SERVICE);
     if (v == null) return;
 
-    Operation targetVibration = VibrateFactory.getVibration(type);
+    Vibrate targetVibration = VibrateFactory.getVibration(type);
 
-    if (!targetVibration.isPresent()) {
+    if (targetVibration == null) {
       return;
     }
 

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
@@ -4,7 +4,6 @@ package com.mkuczera;
 import android.os.Vibrator;
 import android.content.Context;
 import android.provider.Settings;
-import android.view.HapticFeedbackConstants;
 import com.mkuczera.VibrateFactory;
 
 import com.facebook.react.bridge.NativeModule;
@@ -38,8 +37,7 @@ public class RNReactNativeHapticFeedbackModule extends ReactContextBaseJavaModul
     Vibrator v = (Vibrator) reactContext.getSystemService(Context.VIBRATOR_SERVICE);
     if (v == null) return;
 
-    Operation targetVibration = VibrateFactory
-      .getOperation(type)
+    Operation targetVibration = VibrateFactory.getVibration(type);
 
     if (!targetVibration.isPresent()) {
       return;

--- a/android/src/main/java/com/mkuczera/VibrateFactory/Vibrate.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/Vibrate.java
@@ -1,4 +1,6 @@
 
+package com.mkuczera;
+
 import android.os.Vibrator;
 
 public interface Vibrate {

--- a/android/src/main/java/com/mkuczera/VibrateFactory/Vibrate.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/Vibrate.java
@@ -1,0 +1,6 @@
+
+import android.os.Vibrator;
+
+public interface Vibrate {
+    public void apply(Vibrator v);
+}

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateFactory.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateFactory.java
@@ -4,6 +4,16 @@ package com.mkuczera;
 import android.view.HapticFeedbackConstants;
 import android.os.VibrationEffect;
 
+import com.mkuczera.Vibrate;
+import com.mkuczera.VibrateWithDuration;
+import com.mkuczera.VibrateWithHapticConstant;
+import com.mkuczera.VibrateWithCreatePredefined;
+
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Optional;
+
 public class VibrateFactory {
     static Map<String, Vibrate> vibrateMap = new HashMap<>();
     static {
@@ -30,7 +40,7 @@ public class VibrateFactory {
         vibrateMap.put("effectTick", new VibrateWithCreatePredefined(VibrationEffect.EFFECT_TICK));
     }
 
-    public static Optional<Vibrate> getVibration(String type) {
-        return Optional.ofNullable(vibrateMap.get(type));
+    public static Vibrate getVibration(String type) {
+        return vibrateMap.get(type);
     }
 }

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateFactory.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateFactory.java
@@ -1,0 +1,36 @@
+
+package com.mkuczera;
+
+import android.view.HapticFeedbackConstants;
+import android.os.VibrationEffect;
+
+public class VibrateFactory {
+    static Map<String, Vibrate> vibrateMap = new HashMap<>();
+    static {
+        vibrateMap.put("impactLight", new VibrateWithDuration(new long[]{0, 20}));
+        vibrateMap.put("impactMedium", new VibrateWithDuration(new long[]{0, 40};));
+        vibrateMap.put("impactHeavy", new VibrateWithDuration(new long[]{0, 60}));
+        vibrateMap.put("notificationSuccess", new VibrateWithDuration(new long[]{0, 40 ,60, 20}));
+        vibrateMap.put("notificationWarning", new VibrateWithDuration(new long[]{0, 20, 60, 40}));
+        vibrateMap.put("notificationError", new VibrateWithDuration(new long[]{0, 20, 40, 30, 40, 40}));
+        vibrateMap.put("rigid", new VibrateWithDuration(new long[]{0, 30}));
+        vibrateMap.put("soft", new VibrateWithDuration(new long[]{0, 10}));
+        vibrateMap.put("clockTick", new VibrateWithHapticConstant(HapticFeedbackConstants.CLOCK_TICK));
+        vibrateMap.put("contextClick", new VibrateWithHapticConstant(HapticFeedbackConstants.CONTEXT_CLICK));
+        vibrateMap.put("keyboardPress", new VibrateWithHapticConstant(HapticFeedbackConstants.KEYBOARD_PRESS));
+        vibrateMap.put("keyboardRelease", new VibrateWithHapticConstant(HapticFeedbackConstants.KEYBOARD_RELEASE));
+        vibrateMap.put("keyboardTap", new VibrateWithHapticConstant(HapticFeedbackConstants.KEYBOARD_TAP));
+        vibrateMap.put("longPress", new VibrateWithHapticConstant(HapticFeedbackConstants.LONG_PRESS));
+        vibrateMap.put("textHandleMove", new VibrateWithHapticConstant(HapticFeedbackConstants.TEXT_HANDLE_MOVE));
+        vibrateMap.put("virtualKey", new VibrateWithHapticConstant(HapticFeedbackConstants.VIRTUAL_KEY));
+        vibrateMap.put("virtualKeyRelease", new VibrateWithHapticConstant(HapticFeedbackConstants.VIRTUAL_KEY_RELEASE));
+        vibrateMap.put("effectClick", new VibrateWithCreatePredefined(VibrationEffect.EFFECT_CLICK));
+        vibrateMap.put("effectDoubleClick", new VibrateWithCreatePredefined(VibrationEffect.EFFECT_DOUBLE_CLICK));
+        vibrateMap.put("effectHeavyClick", new VibrateWithCreatePredefined(VibrationEffect.EFFECT_HEAVY_CLICK));
+        vibrateMap.put("effectTick", new VibrateWithCreatePredefined(VibrationEffect.EFFECT_TICK));
+    }
+
+    public static Optional<Vibrate> getVibration(String type) {
+        return Optional.ofNullable(vibrateMap.get(type));
+    }
+}

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateFactory.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateFactory.java
@@ -8,7 +8,7 @@ public class VibrateFactory {
     static Map<String, Vibrate> vibrateMap = new HashMap<>();
     static {
         vibrateMap.put("impactLight", new VibrateWithDuration(new long[]{0, 20}));
-        vibrateMap.put("impactMedium", new VibrateWithDuration(new long[]{0, 40};));
+        vibrateMap.put("impactMedium", new VibrateWithDuration(new long[]{0, 40}));
         vibrateMap.put("impactHeavy", new VibrateWithDuration(new long[]{0, 60}));
         vibrateMap.put("notificationSuccess", new VibrateWithDuration(new long[]{0, 40 ,60, 20}));
         vibrateMap.put("notificationWarning", new VibrateWithDuration(new long[]{0, 20, 60, 40}));

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateFactory.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateFactory.java
@@ -1,18 +1,16 @@
 
 package com.mkuczera;
 
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Optional;
+
 import android.view.HapticFeedbackConstants;
 import android.os.VibrationEffect;
-
 import com.mkuczera.Vibrate;
 import com.mkuczera.VibrateWithDuration;
 import com.mkuczera.VibrateWithHapticConstant;
 import com.mkuczera.VibrateWithCreatePredefined;
-
-
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Optional;
 
 public class VibrateFactory {
     static Map<String, Vibrate> vibrateMap = new HashMap<>();

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithCreatePredefined.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithCreatePredefined.java
@@ -1,6 +1,9 @@
 
+package com.mkuczera;
+
 import android.os.Vibrator;
 import android.os.VibrationEffect;
+import android.os.Build;
 
 public class VibrateWithCreatePredefined implements Vibrate {
     int hapticConstant = 0;

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithCreatePredefined.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithCreatePredefined.java
@@ -1,0 +1,19 @@
+
+import android.os.Vibrator;
+import android.os.VibrationEffect;
+
+public class VibrateWithCreatePredefined implements Vibrate {
+    int hapticConstant = 0;
+
+    VibrateWithCreatePredefined(int hapticConstant) {
+        this.hapticConstant = hapticConstant;
+    }
+
+    @Override
+    public void apply(Vibrator v) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+        v.vibrate(VibrationEffect.createPredefined(this.hapticConstant));
+    }
+}

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithDuration.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithDuration.java
@@ -1,4 +1,6 @@
 
+package com.mkuczera;
+
 import android.os.Vibrator;
 
 public class VibrateWithDuration implements Vibrate {

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithDuration.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithDuration.java
@@ -1,0 +1,15 @@
+
+import android.os.Vibrator;
+
+public class VibrateWithDuration implements Vibrate {
+    long durations[] = {};
+
+    public VibrateWithDuration(long[] durations) {
+        this.durations = durations;
+    }
+
+    @Override
+    public void apply(Vibrator v) {
+        v.vibrate(this.durations, -1);
+    }
+}

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithHapticConstant.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithHapticConstant.java
@@ -1,0 +1,15 @@
+
+import android.os.Vibrator;
+
+public class VibrateWithHapticConstant implements Vibrate {
+    int hapticConstant = 0;
+
+    public VibrateWithHapticConstant(int hapticConstant) {
+        this.hapticConstant = hapticConstant;
+    }
+
+    @Override
+    public void apply(Vibrator v) {
+        v.vibrate(this.hapticConstant);
+    }
+}

--- a/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithHapticConstant.java
+++ b/android/src/main/java/com/mkuczera/VibrateFactory/VibrateWithHapticConstant.java
@@ -1,4 +1,6 @@
 
+package com.mkuczera;
+
 import android.os.Vibrator;
 
 public class VibrateWithHapticConstant implements Vibrate {

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,11 @@ declare module "react-native-haptic-feedback" {
     | "longPress"
     | "textHandleMove"
     | "virtualKey"
-    | "virtualKeyRelease";
+    | "virtualKeyRelease"
+    | "effectClick"
+    | "effectDoubleClick"
+    | "effectHeavyClick"
+    | "effectTick";
 
   interface HapticOptions {
     enableVibrateFallback?: boolean;


### PR DESCRIPTION
For fixing issue [#4355](https://github.com/Expensify/App/issues/4355)

This PR will add 4 new vibration methods for Android.
Namely, `effectClick`, `effectDoubleClick`, `effectHeavyClick`, and `effectTick`.

Android reference to the methods can be found [here](https://developer.android.com/reference/android/os/VibrationEffect#createPredefined(int)).

I also got rid of rid of the long _switch case_ for a cleaner code.
Adding new vibration methods in future is as easy as overriding `apply()` from the `Vibrate` interface.
